### PR TITLE
extract rustfmt into own workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,9 +48,6 @@ jobs:
     - name: Cache Dependencies
       uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
 
-    - name: Format
-      run: cargo fmt --all -- --check
-
     - name: Compile
       run: cargo test --no-run --locked
 

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,30 @@
+name: Rust-Format
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+
+jobs:
+  delivery:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      fetch-depth: 20
+    
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        components: rustfmt, rust-src
+    
+    - name: Cache Dependencies
+      uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+
+    - name: Format
+      run: cargo fmt --all -- --check

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -5,9 +5,19 @@ on:
     branches:
     - master
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CI: 1
+  RUST_BACKTRACE: short
+  RUSTFLAGS: "-D warnings -W rust-2021-compatibility"
+  RUSTUP_MAX_RETRIES: 10
+
 jobs:
-  delivery:
+  rustfmt:
+    name: Rustformat
     runs-on: ubuntu-latest
+    
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,4 +1,4 @@
-name: Rust-Format
+name: RustFormat
 on:
   pull_request:
   push:


### PR DESCRIPTION
rustfmt does not need to run three times on all OS so it is extracted into its own workflow.